### PR TITLE
roles = [ "service:role" ]  のconf自動設定をsupport

### DIFF
--- a/templates/default/mackerel-agent.conf.erb
+++ b/templates/default/mackerel-agent.conf.erb
@@ -1,3 +1,5 @@
 apikey = "<%= node['mackerel-agent']['apikey'] %>"
 apibase = "<%= node['mackerel-agent']['apibase'] %>"
+<% if node['mackerel-agent']['service'] && node['mackerel-agent']['role']  %>
 roles = [ "<%= node['mackerel-agent']['service'] %>:<%= node['mackerel-agent']['role'] %>" ]
+<% end %>


### PR DESCRIPTION
roles のconf自動設定をsupport 

```
 "mackerel-agent": {
      "service": "hoge",
      "role": "fuga"
  }
```

このattirbuteがない場合には出力しない。
