### PR TITLE
Fix yum cookbook version

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.0'
 
 depends 'apt'
-depends 'yum'
+depends 'yum', '>= 3.0'
 
 %w(debian ubuntu redhat centos amazon).each do |os|
   supports os


### PR DESCRIPTION
The yum cookbook v3.x.x is not compatible with v2.x.x DSL.
