### PR TITLE
Change action of service[mackerel-agent] from restart to start.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -65,5 +65,5 @@ end
 
 service 'mackerel-agent' do
   supports :status => true, :restart => true
-  action [:enable, :restart]
+  action [:enable, :start]
 end


### PR DESCRIPTION
actionが`:restart`だとChefを実行するたびにリスタートがかかるので`:start`に変更しました。
