### PR TITLE
Support new mackerel-agent for Amazon Linux

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -32,10 +32,12 @@ if platform?('centos') or platform?('redhat') or platform?('amazon')
       action :add
     end
   end
+  repo_url = "http://yum.mackerel.io/centos/$basearch"
+  repo_url = "http://yum.mackerel.io/amznlinux/$releasever/$basearch" if platform?('amazon')
   yum_repository "mackerel" do
     gpgkey gpgkey_url if yum_cookbook_ver >= Gem::Version.new('3.0.0')
     description "mackerel-agent monitoring"
-    url "http://yum.mackerel.io/centos/$basearch"
+    url repo_url
     action :add
   end
 elsif platform?('debian') or platform?('ubuntu')


### PR DESCRIPTION
## WHAT is this
Supporting new Amazon Linux repo

## WHY this change is needed
To install mackerel-agent  on Amazon Linux 2016.03 with Chef

## REF

- [Amazon Linuxの正式サポートについて - Mackerel ブログ #mackerelio](https://mackerel.io/ja/blog/entry/2016/03/28/195614)