### PR TITLE
Support to configure environment variables opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,17 @@ default['mackerel-agent']['conf']['roles'] = nil
 default['mackerel-agent']['start_on_setup'] = false
 ```
 
+### Configure environment variable options
+You can configure environment variable options via the following attributes.
+(These all attributes are set to `nil` by default)
+
+```
+default['mackerel-agent']['env_opts']['other_opts'] = nil
+default['mackerel-agent']['env_opts']['auto_retirement'] = nil
+default['mackerel-agent']['env_opts']['http_proxy'] = nil
+default['mackerel-agent']['env_opts']['mackerel_agent_plugin_meta'] = nil
+```
+
 Development
 ===========
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -8,3 +8,8 @@ default['mackerel-agent']['package-action'] = :upgrade
 default['mackerel-agent']['start_on_setup'] = true
 
 default['mackerel-agent']['plugins']['package-action'] = :upgrade
+
+default['mackerel-agent']['env_opts']['other_opts'] = nil
+default['mackerel-agent']['env_opts']['auto_retirement'] = nil
+default['mackerel-agent']['env_opts']['http_proxy'] = nil
+default['mackerel-agent']['env_opts']['mackerel_agent_plugin_meta'] = nil

--- a/spec/mackerel-agent_spec.rb
+++ b/spec/mackerel-agent_spec.rb
@@ -12,6 +12,16 @@ describe file('/etc/mackerel-agent/mackerel-agent.conf') do
   it { should be_file }
 end
 
+env_file_path = ''
+if ['centos', 'redhat', 'amazon'].include?(os[:family])
+  env_file_path = '/etc/sysconfig/mackerel-agent'
+elsif ['debian', 'ubuntu'].include?(os[:family])
+  env_file_path = '/etc/default/mackerel-agent'
+end
+describe file(env_file_path) do
+  it { should be_file }
+end
+
 #default package is not install mackerel-agent-plugins
 describe package('mackerel-agent-plugins') do
   it { should_not be_installed }

--- a/templates/default/env_file.erb
+++ b/templates/default/env_file.erb
@@ -1,0 +1,6 @@
+# This file is managed by chef
+# DO NOT modify this file directly
+<% if @other_opts %>OTHER_OPTS=<%= @other_opts %><% end %>
+<% if @auto_retirement %>AUTO_RETIREMENT=<%= @auto_retirement %><% end %>
+<% if @http_proxy %>HTTP_PROXY=<%= @http_proxy %><% end %>
+<% if @mackerel_agent_plugin_meta %>MACKEREL_AGENT_PLUGIN_META=<%= @mackerel_agent_plugin_meta %><% end %>


### PR DESCRIPTION
## WHAT
Enable to configure environment variables options via Chef attributes (e.g. `AUTO_RETIREMENT`).

## WHY
Official Chef cookbook should cover all the settings for mackerel-agent.

## REF

- [mackerel-agent仕様 - Mackerel ヘルプ](https://mackerel.io/ja/docs/entry/spec/agent)
- [Auto Scaling環境で使う - Mackerel ヘルプ](https://mackerel.io/ja/docs/entry/howto/auto-scaling)
- https://github.com/mackerelio/mackerel-agent/blob/888d29abfcc72271d669ea2f57422569d6eb8ae3/metrics/plugin.go#L75-78