### PR TITLE
Fixed README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ SYNPOSIS
 node.default['mackerel-agent']['conf']['apikey'] = 'Your API KEY' # required
 node.default['mackerel-agent']['conf']['roles'] = ["My-Service:app", "Another-Service:db"] # optional
 
-node.default['mackerel-agent']['plugins'] = true #optional
 node.default['mackerel-agent']['conf']['plugin.metrics.vmstat'] = { # optional
   'command' => 'ruby /etc/sensu/plugins/system/vmstat-metrics.rb',
 }


### PR DESCRIPTION
# What is this

Hi, I found that `node['mackerel-agent']['plugins']` attribute is already not supported via https://github.com/mackerelio/cookbook-mackerel-agent/pull/21.

So I fixed `README.md`. Thank you 😄 