### PR TITLE
Remove yum cookbook version constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Requirements
 ============
 
 - Chef 12.5 or higher
-- Ruby 1.9
+- Ruby 2.0
 
 ### Workarounds for old chef (11.x ~ 12.4.x)
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ mackerel-agent is a server monitoring agent for https://mackerel.io .
 Requirements
 ============
 
-- Chef 11 or higher
+- Chef 12.5 or higher
 - Ruby 1.9
 
-### For old chef (11.x ~ 12.4.x) users
+### Workarounds for old chef (11.x ~ 12.4.x)
 
 On old chef (11.x ~ 12.4.x), chef may throw error below:
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Requirements
 - Chef 11 or higher
 - Ruby 1.9
 
-### For chef 11 users
+### For old chef (11.x ~ 12.4.x) users
 
-On chef 11, chef may throw error below:
+On old chef (11.x ~ 12.4.x), chef may throw error below:
 
 ```
 ================================================================================
@@ -24,9 +24,21 @@ NoMethodError
 undefined method `property' for #<Class:0x00000003c9a088>
 ```
 
-This is because `property` method in latest apt / yum cookbooks does not exist in chef 11.
+This is because `property` method in latest apt / yum cookbooks does not exist before chef 12.5.
 
-To fix this, specify apt cookbook and yum cookbook to use version __prior to 4.0__ in `Berksfile`.
+
+#### Chef 12.0.x ~ 12.4.x
+
+Use [compat_resource](https://github.com/chef-cookbooks/compat_resource) backports.
+
+```ruby
+# Berksfile
+cookbook 'compat_resource'
+```
+
+#### Chef 11.x
+
+Specify apt cookbook and yum cookbook to use version __prior to 4.0__ in `Berksfile`.
 
 ```ruby
 # Berksfile

--- a/README.md
+++ b/README.md
@@ -10,6 +10,30 @@ Requirements
 - Chef 11 or higher
 - Ruby 1.9
 
+### For chef 11 users
+
+On chef 11, chef may throw error below:
+
+```
+================================================================================
+Recipe Compile Error in /var/chef/cache/cache/cookbooks/yum/resources/globalconfig.rb
+================================================================================
+
+NoMethodError
+-------------
+undefined method `property' for #<Class:0x00000003c9a088>
+```
+
+This is because `property` method in latest apt / yum cookbooks does not exist in chef 11.
+
+To fix this, specify apt cookbook and yum cookbook to use version __prior to 4.0__ in `Berksfile`.
+
+```ruby
+# Berksfile
+cookbook 'apt', '< 4.0'
+cookbook 'yum', '< 4.0'
+```
+
 SYNPOSIS
 ========
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '2.0.0'
 
 depends 'apt'
-depends 'yum', '< 4.0'
+depends 'yum'
 
 %w(debian ubuntu redhat centos amazon).each do |os|
   supports os


### PR DESCRIPTION
- Remove `yum` cookbook version constraint to use new `yum` cookbook.
  - This removal may cause error in chef 11.x ~ 12.4.x, because latest apt / yum cookbook does not support version  prior to 12.5.0.
    - (Current version also cause error because of `apt` cookbook.)
- Add notes for old chef users to README.md.