### PR TITLE
Fix around AmazonLinux 2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,7 @@ GEM
     multipart-post (2.0.0)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
-    net-ssh (4.2.0)
+    net-ssh (5.0.2)
     net-telnet (0.1.1)
     nio4r (2.2.0)
     octokit (4.8.0)
@@ -132,9 +132,9 @@ GEM
     solve (2.0.3)
       molinillo (~> 0.4.2)
       semverse (~> 1.1)
-    specinfra (2.73.2)
+    specinfra (2.75.0)
       net-scp
-      net-ssh (>= 2.7, < 5.0)
+      net-ssh (>= 2.7)
       net-telnet
       sfl
     stove (3.2.8)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Requirements
 ============
 
 - Chef 12.5 or higher
+    - For AmazonLinux 2, Chef 14.3.36 or higher is required.
 - Ruby 2.0
 
 ### Workarounds for old chef (11.x ~ 12.4.x)

--- a/docker/amazonlinux-2/Dockerfile
+++ b/docker/amazonlinux-2/Dockerfile
@@ -1,6 +1,6 @@
 FROM amazonlinux:2
 
-RUN rpm -i https://packages.chef.io/files/stable/chef/12.19.36/el/7/chef-12.19.36-1.el7.x86_64.rpm
+RUN rpm -i https://packages.chef.io/files/stable/chef/14.3.37/el/7/chef-14.3.37-1.el7.x86_64.rpm
 RUN yum install -y systemd hostname
 
 RUN install -d -m 755 /cookbooks /etc/chef /var/chef/node
@@ -15,4 +15,5 @@ RUN echo '{"run_list":["recipe[mackerel-agent]"], "mackerel-agent": {"start_on_s
 
 COPY ./cookbooks /cookbooks
 
-RUN chef-client -j /var/chef/node/localhost.json
+# Hack for Chef 14. yum_package fails with EOFError without redirecting stdio...
+RUN chef-client -j /var/chef/node/localhost.json | cat

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -36,15 +36,15 @@ if platform?('centos') or platform?('redhat') or platform?('amazon')
   repo_url = "http://yum.mackerel.io/centos/$basearch"
   yum_key_name = 'RPM-GPG-KEY-mackerel'
   if platform?('amazon')
-    if supports_v2_repository
-      repo_url = "http://yum.mackerel.io/amznlinux/v2/$releasever/$basearch"
-    else
-      repo_url = "http://yum.mackerel.io/amznlinux/$releasever/$basearch"
-    end
+    repo_url = "http://yum.mackerel.io/amznlinux/$releasever/$basearch"
   end
 
   if supports_v2_repository
-    repo_url = "http://yum.mackerel.io/v2/$basearch"
+    if platform?('amazon')
+      repo_url = "http://yum.mackerel.io/amznlinux/v2/$releasever/$basearch"
+    else
+      repo_url = "http://yum.mackerel.io/v2/$basearch"
+    end
     gpgkey_url = gpgkey_url_v2
     yum_key_name = 'RPM-GPG-KEY-mackerel-v2'
   end


### PR DESCRIPTION
- Use the proper repository for AmazonLinux 2
    - Currently it uses the repo for CentOS 7. Works, but unintended
- Update Chef version in CI / README for AL2 GA
    - Chef < 14.3.36 does not work with AL2 GA due to ohai: https://github.com/chef/ohai/issues/1207