### PR TITLE
`bundle update excon` to avoid CVE-2019-16779

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,7 +57,7 @@ GEM
       excon (>= 0.38.0)
       json
     erubis (2.7.0)
-    excon (0.59.0)
+    excon (0.71.0)
     faraday (0.15.2)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.25)
@@ -166,4 +166,4 @@ DEPENDENCIES
   stove (~> 3.2.2)
 
 BUNDLED WITH
-   1.16.1
+   1.17.2


### PR DESCRIPTION
https://github.com/advisories/GHSA-q58g-455p-8vw9

Since excon is a dependency of docker-client, which is a [test dependency of this cookbook](https://github.com/mackerelio/cookbook-mackerel-agent/blob/master/Gemfile#L10), so this CVE does not affect to the users.