### PR TITLE
add [arch=amd64,arm64] to v2 repo

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -66,7 +66,7 @@ elsif platform?('debian') or platform?('ubuntu')
       key gpgkey_url_v2
       distribution 'mackerel'
       components ['contrib']
-      arch 'amd64'
+      arch 'amd64,arm64'
       action :add
     end
   else


### PR DESCRIPTION
We officially started to support arm64.